### PR TITLE
Change url_with->query calls from [] "append" to {} "merge" for files…

### DIFF
--- a/lib/Mojolicious/Plugin/Minion/resources/templates/minion/_limit.html.ep
+++ b/lib/Mojolicious/Plugin/Minion/resources/templates/minion/_limit.html.ep
@@ -6,7 +6,7 @@
       % }
       % else {
         <li class="page-item">
-          % my $url = url_with->query([limit => $i]);
+          % my $url = url_with->query({limit => $i});
           <a class="page-link" href="<%= $url %>"><%= $i %></a>
         </li>
       % }

--- a/lib/Mojolicious/Plugin/Minion/resources/templates/minion/_pagination.html.ep
+++ b/lib/Mojolicious/Plugin/Minion/resources/templates/minion/_pagination.html.ep
@@ -14,7 +14,7 @@
     % }
     % else {
       <li class="page-item">
-        % my $url = url_with->query([offset => 0]);
+        % my $url = url_with->query({offset => 0});
         <a class="page-link" href="<%= $url %>">First</a>
     % }
     </li>
@@ -24,7 +24,7 @@
     % }
     % else {
       <li class="page-item">
-        % my $url = url_with->query([offset => $prev_offset]);
+        % my $url = url_with->query({offset => $prev_offset});
         <a class="page-link" href="<%= $url %>">Previous</a>
     % }
     </li>
@@ -38,7 +38,7 @@
       % }
       % else {
         <li class="page-item">
-          % my $url = url_with->query([offset => ($i - 1) * $limit]);
+          % my $url = url_with->query({offset => ($i - 1) * $limit});
           <a class="page-link" href="<%= $url %>"><%= $i %></a>
         </li>
       % }
@@ -49,7 +49,7 @@
     % }
     % else {
       <li class="page-item">
-        % my $url = url_with->query([offset => $next_offset]);
+        % my $url = url_with->query({offset => $next_offset});
         <a class="page-link" href="<%= $url %>">Next</a>
     % }
     </li>
@@ -59,7 +59,7 @@
     % }
     % else {
       <li class="page-item">
-        % my $url = url_with->query([offset => $last_offset]);
+        % my $url = url_with->query({offset => $last_offset});
         <a class="page-link" href="<%= $url %>">Last</a>
     % }
     </li>

--- a/lib/Mojolicious/Plugin/Minion/resources/templates/minion/jobs.html.ep
+++ b/lib/Mojolicious/Plugin/Minion/resources/templates/minion/jobs.html.ep
@@ -94,7 +94,7 @@
         % my $i = 0;
         % for my $job (@$jobs) {
           % $i++;
-          % my $base = url_with->query([offset => 0]);
+          % my $base = url_with->query({offset => 0});
           <tbody>
             <tr>
               <td>


### PR DESCRIPTION
… limit.html.ep, _pagination.html.ep and jobs.html.ep (closes #78)

### Summary
Change url_with->query calls from [] "append" to {} "merge" to prevent infinite query paremeter appending.

### Motivation
The queries being appended infinitely. Every browser defines its own max query parameter limit, some don't show the query in the address bar when bigger than 64k.

### References
#78 