### PR TITLE
Allow list_jobs to filter by existence of notes keys

### DIFF
--- a/lib/Minion/Backend/Pg.pm
+++ b/lib/Minion/Backend/Pg.pm
@@ -88,10 +88,11 @@ sub list_jobs {
        extract(epoch from started) as started, state, task,
        extract(epoch from now()) as time, count(*) over() as total, worker
      from minion_jobs as j
-     where (id = any ($1) or $1 is null) and (queue = any ($2) or $2 is null)
-       and (state = any ($3) or $3 is null) and (task = any ($4) or $4 is null)
+     where (id = any ($1) or $1 is null) and (notes \? any ($2) or $2 is null)
+       and (queue = any ($3) or $3 is null) and (state = any ($4) or $4 is null)
+       and (task = any ($5) or $5 is null)
      order by id desc
-     limit $5 offset $6', @$options{qw(ids queues states tasks)}, $limit,
+     limit $6 offset $7', @$options{qw(ids notes queues states tasks)}, $limit,
     $offset
   )->expand->hashes->to_array;
 
@@ -536,6 +537,13 @@ These options are currently available:
   ids => ['23', '24']
 
 List only jobs with these ids.
+
+=item notes
+
+  notes => ['foo', 'bar']
+
+List only jobs with one of these notes. Note that this option is EXPERIMENTAL
+and might change without warning!
 
 =item queues
 
@@ -1143,3 +1151,6 @@ $$ language plpgsql;
 
 -- 18 down
 drop function if exists minion_lock(text, int, int);
+
+-- 19 up
+create index on minion_jobs using gin (notes);

--- a/lib/Minion/Command/minion/job.pm
+++ b/lib/Minion/Command/minion/job.pm
@@ -21,6 +21,7 @@ sub run {
     'H|history'     => \my $history,
     'L|locks'       => \my $locks,
     'l|limit=i'     => \(my $limit = 100),
+    'n|notes=s'     => sub { $opts->{notes} = decode_json($_[1]) },
     'o|offset=i'    => \(my $offset = 0),
     'P|parent=s'    => sub { push @{$opts->{parents}}, $_[1] },
     'p|priority=i'  => \$opts->{priority},
@@ -120,8 +121,10 @@ Minion::Command::minion::job - Minion job command
     ./myapp.pl minion job -q important -t foo -t bar -S inactive
     ./myapp.pl minion job -e foo -a '[23, "bar"]'
     ./myapp.pl minion job -e foo -P 10023 -P 10024 -p 5 -q important
+    ./myapp.pl minion job -e 'foo' -n '{"test":123}'
     ./myapp.pl minion job -R -d 10 10023
     ./myapp.pl minion job --remove 10023
+    ./myapp.pl minion job -n '["test"]'
     ./myapp.pl minion job -L
     ./myapp.pl minion job -L some_lock some_other_lock
     ./myapp.pl minion job -b jobs -a '[12]'
@@ -150,6 +153,8 @@ Minion::Command::minion::job - Minion job command
     -m, --mode <name>           Operating mode for your application, defaults to
                                 the value of MOJO_MODE/PLACK_ENV or
                                 "development"
+    --n, notes <JSON>           Notes in JSON format for new job or list only
+                                jobs with one of these notes
     -o, --offset <number>       Number of jobs/workers to skip when listing
                                 them, defaults to 0
     -P, --parent <id>           One or more jobs the new job depends on

--- a/t/pg.t
+++ b/t/pg.t
@@ -24,11 +24,11 @@ my $worker = $minion->repair->worker;
 isa_ok $worker->minion->app, 'Mojolicious', 'has default application';
 
 # Migrate up and down
-is $minion->backend->pg->migrations->active, 18, 'active version is 18';
+is $minion->backend->pg->migrations->active, 19, 'active version is 19';
 is $minion->backend->pg->migrations->migrate(0)->active, 0,
   'active version is 0';
-is $minion->backend->pg->migrations->migrate->active, 18,
-  'active version is 18';
+is $minion->backend->pg->migrations->migrate->active, 19,
+  'active version is 19';
 
 # Register and unregister
 $worker->register;
@@ -422,6 +422,11 @@ is $batch->[1]{queue}, 'default', 'right queue';
 is $batch->[2]{queue}, 'default', 'right queue';
 is $batch->[3]{queue}, 'default', 'right queue';
 ok !$batch->[4], 'no more results';
+$id2   = $minion->enqueue('test' => [] => {notes => {is_test => 1}});
+$batch = $minion->backend->list_jobs(0, 10, {notes => ['is_test']})->{jobs};
+is $batch->[0]{task}, 'test', 'right task';
+ok !$batch->[4], 'no more results';
+ok $minion->job($id2)->remove, 'job removed';
 $batch
   = $minion->backend->list_jobs(0, 10, {queues => ['does_not_exist']})->{jobs};
 is_deeply $batch, [], 'no results';


### PR DESCRIPTION
The idea is to be able to tag jobs with a note, like `$minion->enqueue('test', [], {notes => {test_123 => 1}})`, and then be able to retrieve (and perhaps modify) all jobs tagged similarly with `$minion->backend->list_jobs(0, 100, {notes => ['test_123']})`.

Searching for jobs with specific arguments is a commonly requested feature, but very hard to do efficiently (and correctly), especially when complex data structures are involved. This is a much simpler alternative that should cover most of the use cases of argument searching, and thanks to the GIN index it is also incredibly efficient.

Downside would be that it is not easy to implement for alternative backends like SQLite.