### PR TITLE
Use YAML::XS to show data structures to Minion users

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -28,6 +28,6 @@ WriteMakefile(
       x_IRC => {url => 'irc://chat.freenode.net/#mojo', web => 'https://webchat.freenode.net/#mojo'}
     },
   },
-  PREREQ_PM => {Mojolicious => '8.50'},
+  PREREQ_PM => {Mojolicious => '9.0', 'YAML::XS' => '0.82'},
   test      => {TESTS       => 't/*.t t/*/*.t'}
 );

--- a/lib/Minion.pm
+++ b/lib/Minion.pm
@@ -12,6 +12,7 @@ use Mojo::Loader qw(load_class);
 use Mojo::Promise;
 use Mojo::Server;
 use Mojo::Util qw(scope_guard steady_time);
+use YAML::XS qw(Dump);
 
 has app => sub { $_[0]{app_ref} = Mojo::Server->new->build_app('Mojo::HelloWorld') }, weak => 1;
 has 'backend';
@@ -156,6 +157,8 @@ sub _delegate {
   $self->backend->$method(@_);
   return $self;
 }
+
+sub _dump { local $YAML::XS::Boolean = 'JSON::PP'; Dump(@_) }
 
 sub _iterator {
   my ($self, $jobs, $options) = (shift, shift, shift // {});

--- a/lib/Minion/Command/minion/job.pm
+++ b/lib/Minion/Command/minion/job.pm
@@ -2,7 +2,7 @@ package Minion::Command::minion::job;
 use Mojo::Base 'Mojolicious::Command';
 
 use Mojo::JSON qw(decode_json);
-use Mojo::Util qw(dumper getopt tablify);
+use Mojo::Util qw(getopt tablify);
 
 has description => 'Manage Minion jobs';
 has usage       => sub { shift->extract_usage };
@@ -50,7 +50,7 @@ sub run {
   return $self->_stats if $stats;
 
   # Show history
-  return print dumper $minion->history if $history;
+  return print Minion::_dump($minion->history) if $history;
 
   # List tasks
   return print tablify [map { [$_, $minion->class_for_task($_)] } keys %{$minion->tasks}] if $tasks;
@@ -81,7 +81,7 @@ sub run {
   return $minion->foreground($id) || die "Job is not ready.\n" if $foreground;
 
   # Job info
-  print dumper Minion::_datetime($job->info);
+  print Minion::_dump(Minion::_datetime($job->info));
 }
 
 sub _list_jobs {
@@ -101,12 +101,12 @@ sub _list_workers {
   print tablify \@workers;
 }
 
-sub _stats { print dumper shift->app->minion->stats }
+sub _stats { print Minion::_dump(shift->app->minion->stats) }
 
 sub _worker {
   my $worker = shift->app->minion->backend->list_workers(0, 1, {ids => [shift]})->{workers}[0];
   die "Worker does not exist.\n" unless $worker;
-  print dumper Minion::_datetime($worker);
+  print Minion::_dump(Minion::_datetime($worker));
 }
 
 1;

--- a/lib/Mojolicious/Plugin/Minion/resources/templates/minion/jobs.html.ep
+++ b/lib/Mojolicious/Plugin/Minion/resources/templates/minion/jobs.html.ep
@@ -155,7 +155,7 @@
               <tr>
                 <td colspan="9" class="hiddenRow">
                   <div class="collapse" id="job<%= $i %>">
-                    <pre class="border rounded"><%= dumper Minion::_datetime $job %></pre>
+                    <pre class="border rounded"><%= Minion::_dump(Minion::_datetime($job)) %></pre>
                   </div>
                 </td>
               </tr>

--- a/lib/Mojolicious/Plugin/Minion/resources/templates/minion/workers.html.ep
+++ b/lib/Mojolicious/Plugin/Minion/resources/templates/minion/workers.html.ep
@@ -73,7 +73,7 @@
             <tr>
               <td colspan="7" class="hiddenRow">
                 <div class="collapse" id="worker<%= $i %>">
-                  <pre class="border rounded"><%= dumper Minion::_datetime $worker %></pre>
+                  <pre class="border rounded"><%= Minion::_dump(Minion::_datetime($worker)) %></pre>
                 </div>
               </td>
             </tr>


### PR DESCRIPTION
![yaml](https://user-images.githubusercontent.com/30094/110867628-5ae51f00-82c7-11eb-88bc-29e90d093cbc.png)

This patch switches from `Data::Dumper` to `YAML::XS` to make data structures more readable in the ui. Especially for non-programmers it should be a lot more comfortable. Only downside is a new dependency on `YAML::XS`.