### PR TITLE
Update webchat links to web.libera.chat

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -25,7 +25,7 @@ WriteMakefile(
         url  => 'https://github.com/mojolicious/minion.git',
         web  => 'https://github.com/mojolicious/minion',
       },
-      x_IRC => {url => 'irc://irc.libera.chat/#mojo', web => 'https://kiwiirc.com/nextclient/#ircs://irc.libera.chat/#mojo'}
+      x_IRC => {url => 'irc://irc.libera.chat/#mojo', web => 'https://web.libera.chat/#mojo'}
     },
   },
   PREREQ_PM => {Mojolicious => '9.0', 'YAML::XS' => '0.67'},

--- a/lib/Minion/Guide.pod
+++ b/lib/Minion/Guide.pod
@@ -348,6 +348,6 @@ authors.
 
 If you have any questions the documentation might not yet answer, don't hesitate to ask in the
 L<Forum|https://forum.mojolicious.org> or the official IRC channel C<#mojo> on C<irc.libera.chat>
-(L<chat now!|https://kiwiirc.com/nextclient/#ircs://irc.libera.chat/#mojo>).
+(L<chat now!|https://web.libera.chat/#mojo>).
 
 =cut


### PR DESCRIPTION
### Summary
Use https://web.libera.chat/#mojo for webchat links and metadata.

### Motivation
Simpler links using the official libera.chat webchat

### References
https://github.com/mojolicious/mojo/pull/1789
