### PR TITLE
rely on perltidy --assert-tidy ... instead of using the exit code of git diff

### DIFF
--- a/.github/workflows/perltidy.yml
+++ b/.github/workflows/perltidy.yml
@@ -24,4 +24,5 @@ jobs:
         run: |
           shopt -s extglob globstar nullglob
           export GLOBIGNORE=t/lib/MinionTest/SyntaxErrorTestTask.pm
-          perltidy --pro=.../.perltidyrc -b -bext='/' **/*.p[lm] **/*.t && git diff --exit-code
+          perltidy --assert-tidy --pro=.../.perltidyrc -b -bext='/' **/*.p[lm] **/*.t 
+


### PR DESCRIPTION
### Summary
`perltidy.yaml` fails with this git error:
```
warning: Not a git repository. Use --no-index to compare two paths outside a working tree
usage: git diff --no-index [<options>] <path> <path>
```

... when it should pass with a nice ✅

### Motivation
CI should only fail when the software is broken, or breaks the rules. 

### References
Running perl tidy this way will signal an error and fail if you make a file untidy, as seen here: 
https://github.com/guest20/minion/actions/runs/5230545384/jobs/9444153383

The pass should be visible on this PR because minion is already tidy:
https://github.com/guest20/minion/actions/runs/5230551618/jobs/9444163468