### PR TITLE
encode UTF-8 YAML::XS::Dump

### DIFF
--- a/lib/Minion.pm
+++ b/lib/Minion.pm
@@ -154,7 +154,7 @@ sub _delegate {
   return $self;
 }
 
-sub _dump { local $YAML::XS::Boolean = 'JSON::PP'; Dump(@_) }
+sub _dump { local $YAML::XS::Boolean = 'JSON::PP'; Mojo::Util::decode 'UTF-8', Dump(@_) }
 
 sub _iterator {
   my ($self, $jobs, $options) = (shift, shift, shift // {});


### PR DESCRIPTION
### Summary
encode UTF-8 YAML::XS::Dump in Minion Admin list jobs

### Motivation
Is this an appropriate thing to do?  I have notes with utf8 and they don't show up right in the Admin page, but adding this make it show up right.  Is there another way to get the notes to render UTF-8 correctly?
