### PR TITLE
Expose the Lock ID on the locks page

### DIFF
--- a/lib/Minion/Backend.pm
+++ b/lib/Minion/Backend.pm
@@ -494,6 +494,12 @@ These fields are currently available:
 
 Epoch time this lock will expire.
 
+=item id
+
+  id => 1
+
+Lock id.
+
 =item name
 
   name => 'foo'

--- a/lib/Minion/Backend/Pg.pm
+++ b/lib/Minion/Backend/Pg.pm
@@ -96,7 +96,7 @@ sub list_locks {
   my ($self, $offset, $limit, $options) = @_;
 
   my $locks = $self->pg->db->query(
-    'SELECT name, EXTRACT(EPOCH FROM expires) AS expires, COUNT(*) OVER() AS total FROM minion_locks
+    'SELECT id, name, EXTRACT(EPOCH FROM expires) AS expires, COUNT(*) OVER() AS total FROM minion_locks
      WHERE expires > NOW() AND (name = ANY ($1) OR $1 IS NULL)
      ORDER BY id DESC LIMIT $2 OFFSET $3', $options->{names}, $limit, $offset
   )->hashes->to_array;
@@ -726,6 +726,12 @@ These fields are currently available:
   expires => 784111777
 
 Epoch time this lock will expire.
+
+=item id
+
+  id => 1
+
+Lock id.
 
 =item name
 

--- a/lib/Minion/Command/minion/job.pm
+++ b/lib/Minion/Command/minion/job.pm
@@ -92,7 +92,7 @@ sub _list_jobs {
 sub _list_locks {
   my $locks = shift->app->minion->backend->list_locks(@_)->{locks};
   @$locks = map { Minion::_datetime($_) } @$locks;
-  print tablify [map { [@$_{qw(name expires)}] } @$locks];
+  print tablify [map { [@$_{qw(id name expires)}] } @$locks];
 }
 
 sub _list_workers {

--- a/lib/Mojolicious/Plugin/Minion/resources/templates/minion/locks.html.ep
+++ b/lib/Mojolicious/Plugin/Minion/resources/templates/minion/locks.html.ep
@@ -23,6 +23,7 @@
         <thead>
           <tr>
             <th><input class="checkall" data-check="name" type="checkbox"></th>
+            <th>Lock ID</th>
             <th>Name</th>
             <th>Expires</th>
           </tr>
@@ -36,6 +37,9 @@
               <tr>
                 <td>
                   <input type="checkbox" name="name" value="<%= $lock->{name} %>">
+                </td>
+                <td id="lock_id">
+                  <%= $lock->{id} %>
                 </td>
                 <td>
                   <a href="<%= url_for->query({name => $lock->{name}}) %>">


### PR DESCRIPTION
### Summary
Expose the lock ID on the Minion admin locks page

### Motivation

I employ locks to manage job execution across multiple worker boxes. However, apart from querying the database, I'm unable to determine whether the locks are being rotated. The expiration time decreasing provides some indication, but if the jobs finish within a minute, I can't tell solely from the lock screen whether they are cycling or being held for that minute.

Since it's only retrieving the ID, which would be part of the index, there should be no slowdown in the database.


### References
Sorry this is a drive by pull request
