### PR TITLE
build tarball using ustar format for better compatibility

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -29,5 +29,6 @@ WriteMakefile(
     },
   },
   PREREQ_PM => {Mojolicious => '9.0', 'YAML::XS' => '0.67'},
-  test      => {TESTS       => 't/*.t t/*/*.t'}
+  test      => {TESTS       => 't/*.t t/*/*.t'},
+  dist      => {TARFLAGS    => '-c -v --format=ustar -f' },
 );


### PR DESCRIPTION
### Summary
build tarball using ustar format for better compatibility

### Motivation
ustar is the baseline format that doesn't include extra headers that will cause warnings on any other tar version. Without it, the archive will often end up with headers like
`LIBARCHIVE.xattr.com.apple.quarantine`, which will produce warnings when extracted with GNU tar.
