### PR TITLE
add backend-agnostic connection check

### DIFF
--- a/lib/Minion/Backend.pm
+++ b/lib/Minion/Backend.pm
@@ -23,6 +23,7 @@ sub list_locks        { croak 'Method "list_locks" not implemented by subclass' 
 sub list_workers      { croak 'Method "list_workers" not implemented by subclass' }
 sub lock              { croak 'Method "lock" not implemented by subclass' }
 sub note              { croak 'Method "note" not implemented by subclass' }
+sub ping              { croak 'Method "ping" not implemented by subclass' }
 sub receive           { croak 'Method "receive" not implemented by subclass' }
 sub register_worker   { croak 'Method "register_worker" not implemented by subclass' }
 sub remove_job        { croak 'Method "remove_job" not implemented by subclass' }
@@ -57,6 +58,7 @@ Minion::Backend - Backend base class
   sub list_workers      {...}
   sub lock              {...}
   sub note              {...}
+  sub ping              {...}
   sub receive           {...}
   sub register_worker   {...}
   sub remove_job        {...}
@@ -615,6 +617,12 @@ Number of shared locks with the same name that can be active at the same time, d
 
 Change one or more metadata fields for a job. Setting a value to C<undef> will remove the field. Meant to be overloaded
 in a subclass.
+
+=head2 ping
+
+  my $bool = $backend->ping;
+
+Check backend connection.
 
 =head2 receive
 

--- a/lib/Minion/Backend/Pg.pm
+++ b/lib/Minion/Backend/Pg.pm
@@ -16,6 +16,11 @@ sub broadcast {
     {json => [[$command, @$args]]}, $ids)->rows;
 }
 
+sub ping {
+  my ($self) = @_;
+  return $self->pg->db->ping();
+}
+
 sub dequeue {
   my ($self, $id, $wait, $options) = @_;
 


### PR DESCRIPTION
### Summary
Each minion class backend uses a different attribute for its database connection object ('pg' for postgres backend, 'mysql' for mysql backend, etc). This makes low-level operations implementation-dependant.

### Motivation
The change allows to send regular traffic to the backend, in order to avoid the database connection being closed for timeout, in a backend-agnostic way. 

### References
See [discussion #2229](https://github.com/mojolicious/mojo/discussions/2229).
